### PR TITLE
Compatibility with older version of virt-install

### DIFF
--- a/create-vm
+++ b/create-vm
@@ -27,6 +27,7 @@ STORAGE=80
 BRIDGE=virbr0
 MAC=
 VERBOSE=
+VIRT_TYPE=$(command -v kvm-ok > /dev/null && echo kvm || echo qemu)
 
 usage()
 {
@@ -45,6 +46,9 @@ OPTIONS:
    -s      Amount of storage to allocate in GB (defaults to ${STORAGE})
    -b      Bridge interface to use (defaults to ${BRIDGE})
    -m      MAC address to use (default is to use a randomly-generated MAC)
+   -t      The hypervisor to install on. Example choices are kvm, qemu, or xen.
+           Example choices are kvm, qemu, or xen. (defaults to ${VIRT_TYPE})
+           Available options are listed via 'virsh capabilities' in the <domain> tags.
    -v      Verbose
 EOF
 }
@@ -64,6 +68,7 @@ while getopts "h:n:i:k:r:c:s:b:m:v" option; do
         s) STORAGE=${OPTARG};;
         b) BRIDGE=${OPTARG};;
         m) MAC=${OPTARG};;
+        t) VIRT_TYPE=${OPTARG};;
         v) VERBOSE=1;;
         *)
             usage
@@ -130,14 +135,11 @@ while IFS= read -r key; do
     echo "      - $key" >> "$VM_IMAGE_DIR/init/user-data"
 done < <(grep -v '^ *#' < "$AUTH_KEYS_FQN")
 
-echo "Generating the cidata ISO file $VM_IMAGE_DIR/images/${HOSTNAME}-cidata.iso"
+echo "Generating the cidata ISO file $VM_IMAGE_DIR/images/${HOSTNAME}-cidata.img"
 (
     cd "$VM_IMAGE_DIR/init/"
-    genisoimage \
-        -output "$VM_IMAGE_DIR/images/${HOSTNAME}-cidata.img" \
-        -volid cidata \
-        -rational-rock \
-        -joliet \
+    cloud-localds \
+        "$VM_IMAGE_DIR/images/${HOSTNAME}-cidata.img" \
         user-data meta-data
 )
 
@@ -148,6 +150,7 @@ fi
 
 virt-install \
     --name="${HOSTNAME}" \
+    --virt-type=${VIRT_TYPE} \
     --network "bridge=${BRIDGE},model=virtio" $MACCMD \
     --import \
     --disk "path=${VM_IMAGE_DIR}/images/${HOSTNAME}.img,format=qcow2" \
@@ -155,11 +158,8 @@ virt-install \
     --ram="${RAM}" \
     --vcpus="${VCPUS}" \
     --autostart \
-    --hvm \
-    --arch x86_64 \
-    --accelerate \
+    --cpu host \
     --check-cpu \
-    --osinfo detect=on,require=off \
     --force \
     --watchdog=default \
     --graphics vnc,listen=0.0.0.0 \

--- a/delete-vm
+++ b/delete-vm
@@ -39,9 +39,8 @@ fi
 if [[ -e $VM_IMAGE ]]; then
     # VM exists
     virsh destroy "$VM"
-    virsh undefine "$VM"
-    rm -fv "$VM_IMAGE" "$CI_IMAGE"
+    virsh undefine "$VM" --remove-all-storage
 else
     echo "Cannot find an VM image file named '$VM_IMAGE'. Attempting undefine..."
-    virsh undefine "$VM"
+    virsh undefine "$VM" --remove-all-storage
 fi

--- a/get-vm-ip
+++ b/get-vm-ip
@@ -33,5 +33,4 @@ if [[ -z $HOSTNAME ]]; then
     exit 1
 fi
 
-MAC=$(virsh domiflist $HOSTNAME | awk '{ print $5 }' | tail -2 | head -1)
-arp -a | grep $MAC | awk '{ print $2 }' | sed 's/[()]//g'
+virsh domifaddr --domain ${HOSTNAME} --source arp | tail -2 | head -1 | awk '{ print $4 }' | sed -E 's/\/[[:digit:]]+//'

--- a/get-vm-ip
+++ b/get-vm-ip
@@ -37,7 +37,7 @@ fi
 
 MAC=$(virsh -q domiflist $HOSTNAME | awk '{ print $5 }')
 
-if [ -z ${IFACE}  ]; then
+if [[ -z ${IFACE}  ]]; then
   arp -e | grep -i $MAC | awk '{ print $1 }'
 else
   arp-scan --interface ${IFACE} --localnet | grep -i $MAC | awk '{ print $1 }'

--- a/get-vm-ip
+++ b/get-vm-ip
@@ -19,13 +19,15 @@
 usage()
 {
 cat << EOF
-usage: $0 hostname
+usage: $0 hostname [iface]
 
-This script will take a virsh-managed VM hostname and return the IP address.
+This script will take a virsh-managed VM hostname and return the IP address. In the case of using the network in the `bridge` mode,
+the arp table will not possibly contain any IP addresses, optionally use alternative method `arp-scan` on specified `iface`.
 EOF
 }
 
 HOSTNAME=$1
+IFACE=$2
 
 if [[ -z $HOSTNAME ]]; then
     echo "ERROR: Hostname is required"
@@ -34,4 +36,9 @@ if [[ -z $HOSTNAME ]]; then
 fi
 
 MAC=$(virsh -q domiflist $HOSTNAME | awk '{ print $5 }')
-arp -e | grep -i $MAC | awk '{ print $1 }'
+
+if [ -z ${IFACE}  ]; then
+  arp -e | grep -i $MAC | awk '{ print $1 }'
+else
+  arp-scan --interface ${IFACE} --localnet | grep -i $MAC | awk '{ print $1 }'
+fi


### PR DESCRIPTION
    * Ubuntu 20.04.6 LTS - compatibility
    * Using `cloud-localds` - as described in cloud-init documentation
    * `virsh` - auto remove all associated storage volumes